### PR TITLE
stop killing random processes that happen to include LED in their inv…

### DIFF
--- a/usr/bin/LED
+++ b/usr/bin/LED
@@ -239,5 +239,5 @@ Examples:
 EOF
 }
 
-ps | grep LED | grep -v grep | awk '{print $1}' | grep -v $$ | xargs kill -9 &> /dev/null
+pkill -9 LED &> /dev/null
 run_led $@ || show_usage


### PR DESCRIPTION
…ocation

I can't "vi /usr/bin/LED" and it's killing me