### PR TITLE
okay, that was mii fault

### DIFF
--- a/usr/bin/shark_framework
+++ b/usr/bin/shark_framework
@@ -100,7 +100,7 @@ function execute_upgrade() {
 
 function wait_for_link() {
     LED LINKSETUP
-    while mii-tool eth0 | grep -q 'eth0: no link'; do
+    until swconfig dev switch0 port 0 get link | grep -q 'link:up'; do
         sleep 1
     done
     LED SETUP


### PR DESCRIPTION
mii-tool doesn't work on the SIX PORT SWITCH that the shark thinks it
is.  Foxtrot was kind enough to point me to swconfig.  This is tested
and functional :us: :us: :rocket: :gb: